### PR TITLE
updated code with fine tuning of prompts for websearch.

### DIFF
--- a/src/ollama_deep_researcher/prompts.py
+++ b/src/ollama_deep_researcher/prompts.py
@@ -4,7 +4,8 @@ from datetime import datetime
 def get_current_date():
     return datetime.now().strftime("%B %d, %Y")
 
-query_writer_instructions="""Your goal is to generate a targeted web search query.
+query_writer_instructions="""Your goal is to generate a targeted web search query, if the user query has site:https://lore.kernel.org then generate query
+along with site:https://lore.kernel.org.
 
 <CONTEXT>
 Current date: {current_date}
@@ -64,13 +65,12 @@ Think carefully about the provided Context first. Then generate a summary of the
 reflection_instructions = """You are an expert research assistant analyzing a summary about {research_topic}.
 
 <GOAL>
-1. Identify knowledge gaps or areas that need deeper exploration
-2. Generate a follow-up question that would help expand your understanding
-3. Focus on technical details, implementation specifics, or emerging trends that weren't fully covered
+1. restrict the summary to code discussions
+2. restrict the search references only site:https://lore.kernel.org.
 </GOAL>
 
 <REQUIREMENTS>
-Ensure the follow-up question is self-contained and includes necessary context for web search.
+Ensure the follow-up question is self-contained and includes necessary context restricted discussions on site:https://lore.kernel.org for web search.
 </REQUIREMENTS>
 
 <FORMAT>
@@ -82,8 +82,8 @@ Format your response as a JSON object with these exact keys:
 <Task>
 Reflect carefully on the Summary to identify knowledge gaps and produce a follow-up query. Then, produce your output following this JSON format:
 {{
-    "knowledge_gap": "The summary lacks information about performance metrics and benchmarks",
-    "follow_up_query": "What are typical performance benchmarks and metrics used to evaluate [specific technology]?"
+    "knowledge_gap": "if summary lacks information about missing strings from the generated query",
+    "follow_up_query": "perform search using site:https://lore.kernel.org on top 3 missing strings."
 }}
 </Task>
 

--- a/src/ollama_deep_researcher/utils.py
+++ b/src/ollama_deep_researcher/utils.py
@@ -151,7 +151,7 @@ def fetch_raw_content(url: str) -> Optional[str]:
         return None
 
 @traceable
-def duckduckgo_search(query: str, max_results: int = 3, fetch_full_page: bool = False) -> Dict[str, List[Dict[str, Any]]]:
+def duckduckgo_search(query: str, max_results: int = 1, fetch_full_page: bool = False) -> Dict[str, List[Dict[str, Any]]]:
     """
     Search the web using DuckDuckGo and return formatted results.
     


### PR DESCRIPTION
1. Fine tuned prompt for "query_writer_instructions" : restricted to look out only with Linux kernel archives.

2. Fine tuned prompt for "reflection_instructions" : restricted reflection to only Linux kernel archive if summary lacks the information while generating the query.